### PR TITLE
Add phase 2 context metadata routing and OpenClaw propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ npm run smoke:phase1
 See `docs/phase1-private-channel-smoke.md` for required environment variables,
 verification queries, and known Phase 1 limitations.
 
+Phase 2 manual-pilot observability smoke:
+
+```sh
+npm run context:set -- --agent-id agent_local_alex --context-version alex-week-2026-04-17
+```
+
+See `docs/phase2-manual-pilot-smoke.md` for the manual workspace convention,
+OpenRouter Broadcast to Braintrust setup, SQLite verification queries, privacy
+notes, and HITL validation record.
+
 ## Module Homes
 
 - `src/config`: environment and service configuration

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ OpenClaw gateway environment:
 - `OPENCLAW_GATEWAY_URL`: OpenClaw protocol v3 WebSocket gateway URL. If unset, the relay keeps using the unconfigured fallback.
 - `OPENCLAW_DEVICE_IDENTITY_JWK`: Ed25519 OKP private JSON Web Key with `x` and `d`. Required when `OPENCLAW_GATEWAY_URL` is set so the relay can sign `connect.challenge`.
 - `OPENCLAW_GATEWAY_TOKEN`: optional shared gateway token. `OPENCLAW_AUTH_TOKEN` is also accepted as a local alias. Device identity is still required because token-only auth does not grant operator write scopes.
-- `OPENCLAW_CLIENT_ID` and `OPENCLAW_CLIENT_MODE`: default to the documented OpenClaw operator client identity, `cli` and `operator`.
+- `OPENCLAW_CLIENT_ID` and `OPENCLAW_CLIENT_MODE`: default to the OpenClaw gateway-compatible client identity, `cli` and `backend`.
 - `OPENCLAW_CLIENT_PLATFORM`: normalized into the signed metadata. Defaults to `node`.
 - `OPENCLAW_DEVICE_FAMILY`: normalized into the signed metadata. Defaults to `server`.
 - `OPENCLAW_CLIENT_VERSION`, `OPENCLAW_LOCALE`, `OPENCLAW_USER_AGENT`, `OPENCLAW_REQUEST_TIMEOUT_MS`: optional gateway metadata and timeout controls.

--- a/docs/phase2-manual-pilot-smoke.md
+++ b/docs/phase2-manual-pilot-smoke.md
@@ -1,0 +1,214 @@
+# Phase 2 Manual Pilot Smoke
+
+This smoke verifies the manual-pilot observability loop:
+
+- The operator manually edits the user's OpenClaw workspace guidance.
+- The relay stores a matching context version label.
+- A routed Discord user message creates local SQLite evidence.
+- OpenRouter Broadcast sends the model trace to Braintrust through external
+  destination configuration.
+
+The relay database must not store therapist summary text in Phase 2. Store only
+the human-readable context label and runtime identifiers needed to reconcile a
+turn with traces.
+
+## Manual Workspace Convention
+
+After receiving the approved weekly summary outside the app, SSH into the
+OpenClaw VM and edit the user's workspace guidance file.
+
+Preferred file:
+
+- `USER.md` for user-specific weekly guidance.
+- Use `AGENTS.md` only if the current OpenClaw runtime reads that more
+  reliably for the workspace.
+
+Add or update a visible header like this:
+
+```md
+## User-Specific Weekly Guidance
+
+Context version: alex-week-2026-04-17
+Updated by: Srujan
+Updated at: 2026-04-17
+Update mode: manual_ssh
+```
+
+Keep the `Context version` value stable and copy the same value into the relay
+metadata with the local command below.
+
+## Record Relay Context Metadata
+
+Seed or point at the relay SQLite database that the Discord bot uses. Then
+record the context label against the active agent or assignment:
+
+```sh
+npm run context:set -- \
+  --agent-id agent_local_alex \
+  --context-version alex-week-2026-04-17 \
+  --updated-by Srujan
+```
+
+Assignment IDs are also supported:
+
+```sh
+npm run context:set -- \
+  --assignment-id assignment_local_alex_private_channel \
+  --context-version alex-week-2026-04-17 \
+  --updated-by Srujan
+```
+
+The command updates relay metadata only. It must not edit OpenClaw workspace
+files or store therapist summary text.
+
+## OpenRouter Broadcast Setup
+
+Configure OpenRouter outside this repo:
+
+1. In OpenRouter, open Settings > Observability.
+2. Enable Broadcast.
+3. Add the Braintrust destination.
+4. Enter the Braintrust API key and project ID.
+5. Use Test Connection and save only after the test passes.
+6. Enable Privacy Mode for the Braintrust destination when the pilot should
+   exclude prompt and completion content from exported traces.
+
+Do not commit Braintrust credentials, OpenRouter API keys, dashboard screenshots
+with secrets, or destination configuration exports.
+
+OpenRouter supports `user`, `session_id`, and custom `trace` metadata for
+Broadcast destinations. The relay now preserves the local IDs and context label
+needed to reconcile traces even if the current OpenClaw gateway cannot forward
+every custom field to OpenRouter yet.
+
+## Run One Safe Turn
+
+Use one safe private test channel that is already present in
+`user_assignments.discord_channel_id`. Do not use a production user channel for
+this smoke.
+
+1. Start or confirm the OpenClaw gateway is reachable.
+2. Start the relay Discord bot with the same database where context metadata was
+   recorded:
+
+   ```sh
+   npm run build
+   RELAY_DATABASE_PATH=data/local.sqlite node --no-warnings dist/main.js --discord
+   ```
+
+3. Send one benign user message in the safe Discord test channel.
+4. Wait for the agent reply to appear in the same channel.
+
+## SQLite Verification
+
+Open the same SQLite database used by the bot and inspect the latest routed user
+turn:
+
+```sql
+SELECT
+  discord_message_id,
+  role,
+  message_type,
+  user_id,
+  expert_id,
+  agent_id,
+  session_id,
+  openclaw_status,
+  openclaw_trace_id,
+  openclaw_provider_response_id,
+  routing_metadata_json
+FROM messages
+WHERE message_type = 'user_message'
+ORDER BY created_at DESC
+LIMIT 5;
+```
+
+Expected local evidence:
+
+- `message_type = 'user_message'`.
+- `openclaw_status = 'ok'` for a successful model turn.
+- `openclaw_trace_id` or `openclaw_provider_response_id` is present when the
+  gateway/runtime returns it.
+- `routing_metadata_json` contains:
+  - `context_version`
+  - `context_update_mode`
+  - `context_updated_at`
+  - `context_updated_by`
+  - `user_id`
+  - `expert_id`
+  - `agent_id`
+  - `discord_channel_id`
+  - `session_id`
+  - `assignment_id`
+  - `environment`
+
+Use a JSON extraction query when the local SQLite build supports it:
+
+```sql
+SELECT
+  discord_message_id,
+  json_extract(routing_metadata_json, '$.context_version') AS context_version,
+  json_extract(routing_metadata_json, '$.context_update_mode') AS context_update_mode,
+  json_extract(routing_metadata_json, '$.session_id') AS metadata_session_id,
+  openclaw_trace_id,
+  openclaw_provider_response_id
+FROM messages
+WHERE message_type = 'user_message'
+ORDER BY created_at DESC
+LIMIT 5;
+```
+
+The expected `context_update_mode` value for Phase 2 is `manual_ssh`.
+
+## Braintrust Verification
+
+In Braintrust, open the project configured as the OpenRouter Broadcast
+destination and select Logs.
+
+Look for the trace created by the safe turn. Depending on the current OpenClaw
+and OpenRouter passthrough behavior, use one or more of:
+
+- Timestamp from the Discord message and SQLite row.
+- OpenRouter model/provider metadata.
+- `user` or `session_id` if the gateway forwards those fields.
+- Custom metadata paths under `trace` if passthrough is available.
+- Local SQLite identifiers such as `openclaw_trace_id`,
+  `openclaw_provider_response_id`, `session_id`, and `context_version`.
+
+Braintrust can filter logs and group related traces by metadata. For this phase,
+record whether `context_version` is visible directly in Braintrust. If it is not
+visible yet, reconcile the trace with SQLite using timestamp and runtime IDs,
+and keep #21's OpenRouter metadata helper as the implementation path for future
+gateway passthrough.
+
+## Privacy Notes
+
+- Do not store therapist summary text in the relay database.
+- Keep context labels human-readable but non-sensitive.
+- Use OpenRouter Braintrust Privacy Mode when prompt and completion content
+  should be excluded from traces.
+- Privacy Mode still allows operational metadata, token counts, timing, model
+  information, and custom metadata to be sent.
+
+## HITL Validation Record
+
+When running the smoke, record:
+
+- Date:
+- Operator:
+- Safe Discord channel:
+- Agent or assignment ID:
+- Context version:
+- SQLite database path:
+- SQLite evidence:
+- Braintrust trace found: yes/no
+- Braintrust-visible metadata:
+- Known limitations:
+
+Known limitation before live validation:
+
+- The relay preserves context metadata locally and exposes an OpenRouter-friendly
+  mapping helper, but the current OpenClaw protocol v3 `chat.send` payload
+  remains compatible with `sessionKey`, `message`, and `idempotencyKey` only.
+  If the gateway does not yet forward `user`, `session_id`, or `trace`, use
+  SQLite runtime IDs to reconcile the Braintrust trace manually.

--- a/migrations/004_context_metadata.sql
+++ b/migrations/004_context_metadata.sql
@@ -1,0 +1,4 @@
+ALTER TABLE agents ADD COLUMN context_version TEXT;
+ALTER TABLE agents ADD COLUMN context_update_mode TEXT;
+ALTER TABLE agents ADD COLUMN context_updated_at TEXT;
+ALTER TABLE agents ADD COLUMN context_updated_by TEXT;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "context:set": "npm run build && node --no-warnings dist/context.js",
     "dev": "npm run build && node --no-warnings dist/main.js --synthetic",
     "seed:local": "npm run build && node --no-warnings dist/seed.js examples/local-routing.seed.example.json data/local.sqlite",
     "smoke:phase1": "npm run build && node --no-warnings scripts/phase1-private-channel-smoke.mjs",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,115 @@
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { loadConfig } from "./config/index.js";
+import { setContextMetadata } from "./db/context.js";
+import { applyPhase1Schema } from "./db/seed.js";
+import { openSqliteDatabase } from "./db/sqlite.js";
+
+declare const process: {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  exit(code?: number): never;
+  exitCode?: number;
+};
+
+type ContextSetArgs = {
+  "agent-id"?: string;
+  "assignment-id"?: string;
+  "context-version"?: string;
+  "updated-by"?: string;
+};
+
+export async function runContextSetCommand(
+  argv: string[] = process.argv.slice(2),
+  env: Record<string, string | undefined> = process.env
+) {
+  const values = parseContextArgs(argv);
+  const config = loadConfig(env);
+
+  if (typeof values["context-version"] !== "string") {
+    throw new Error("--context-version is required.");
+  }
+
+  await mkdir(dirname(config.databasePath), { recursive: true });
+  const database = openSqliteDatabase(config.databasePath);
+
+  try {
+    applyPhase1Schema(database);
+    return setContextMetadata(database, {
+      agentId: values["agent-id"],
+      assignmentId: values["assignment-id"],
+      contextVersion: values["context-version"],
+      updatedBy: values["updated-by"]
+    });
+  } finally {
+    database.close();
+  }
+}
+
+function parseContextArgs(argv: string[]): ContextSetArgs {
+  const values: ContextSetArgs = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--agent-id") {
+      values["agent-id"] = argv[++index];
+      continue;
+    }
+
+    if (arg === "--assignment-id") {
+      values["assignment-id"] = argv[++index];
+      continue;
+    }
+
+    if (arg === "--context-version") {
+      values["context-version"] = argv[++index];
+      continue;
+    }
+
+    if (arg === "--updated-by") {
+      values["updated-by"] = argv[++index];
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printUsageAndExit();
+    }
+
+    throw new Error(`Unknown argument ${arg}.`);
+  }
+
+  return values;
+}
+
+function printUsageAndExit(): never {
+  console.log(
+    [
+      "Usage: npm run context:set -- --agent-id <id> --context-version <label> [--updated-by <name>]",
+      "   or: npm run context:set -- --assignment-id <id> --context-version <label> [--updated-by <name>]"
+    ].join("\n")
+  );
+  process.exit(0);
+}
+
+async function main() {
+  try {
+    console.log(JSON.stringify(await runContextSetCommand(), null, 2));
+  } catch (error: unknown) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+if (isMainModule()) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+function isMainModule(): boolean {
+  const entrypoint = process.argv[1];
+  return typeof entrypoint === "string" && import.meta.url === new URL(`file://${entrypoint}`).href;
+}

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -19,8 +19,15 @@ export type ContextMetadataRecord = {
   contextUpdatedBy: string | null;
 };
 
+export type ContextMetadataErrorCode =
+  | "invalid_context_version"
+  | "invalid_target"
+  | "missing_metadata"
+  | "unknown_agent"
+  | "unknown_assignment";
+
 export class ContextMetadataError extends Error {
-  constructor(message: string) {
+  constructor(message: string, readonly code: ContextMetadataErrorCode) {
     super(message);
     this.name = "ContextMetadataError";
   }
@@ -80,7 +87,7 @@ export function getContextMetadata(
     .get(agentId) as ContextMetadataRow | undefined;
 
   if (!row) {
-    throw new ContextMetadataError(`Unknown agent id ${agentId}.`);
+    throw new ContextMetadataError(`Unknown agent id ${agentId}.`, "unknown_agent");
   }
 
   if (
@@ -91,7 +98,10 @@ export function getContextMetadata(
     typeof row.context_updated_at !== "string" ||
     row.context_updated_at.trim() === ""
   ) {
-    throw new ContextMetadataError(`Agent ${agentId} does not have recorded context metadata.`);
+    throw new ContextMetadataError(
+      `Agent ${agentId} does not have recorded context metadata.`,
+      "missing_metadata"
+    );
   }
 
   return {
@@ -112,10 +122,7 @@ export function resolveContextMetadata(
   try {
     return getContextMetadata(database, agentId, targetType);
   } catch (error) {
-    if (
-      error instanceof ContextMetadataError &&
-      error.message === `Agent ${agentId} does not have recorded context metadata.`
-    ) {
+    if (error instanceof ContextMetadataError && error.code === "missing_metadata") {
       return null;
     }
 
@@ -145,7 +152,10 @@ function resolveContextTarget(
   const hasAssignmentId = normalizeOptionalText(input.assignmentId) !== null;
 
   if (hasAgentId === hasAssignmentId) {
-    throw new ContextMetadataError("Provide exactly one of --agent-id or --assignment-id.");
+    throw new ContextMetadataError(
+      "Provide exactly one of --agent-id or --assignment-id.",
+      "invalid_target"
+    );
   }
 
   if (hasAgentId) {
@@ -162,7 +172,7 @@ function resolveContextTarget(
       .get(agentId) as { id: string } | undefined;
 
     if (!row) {
-      throw new ContextMetadataError(`Unknown agent id ${agentId}.`);
+      throw new ContextMetadataError(`Unknown agent id ${agentId}.`, "unknown_agent");
     }
 
     return { agentId: row.id, targetType: "agent" };
@@ -181,7 +191,10 @@ function resolveContextTarget(
     .get(assignmentId) as AssignmentTargetRow | undefined;
 
   if (!row) {
-    throw new ContextMetadataError(`Unknown active assignment id ${assignmentId}.`);
+    throw new ContextMetadataError(
+      `Unknown active assignment id ${assignmentId}.`,
+      "unknown_assignment"
+    );
   }
 
   return { agentId: row.agent_id, targetType: "assignment" };
@@ -190,7 +203,7 @@ function resolveContextTarget(
 function normalizeRequiredText(value: string, label: string): string {
   const normalized = normalizeOptionalText(value);
   if (!normalized) {
-    throw new ContextMetadataError(`${label} is required.`);
+    throw new ContextMetadataError(`${label} is required.`, "invalid_context_version");
   }
 
   return normalized;

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -104,6 +104,25 @@ export function getContextMetadata(
   };
 }
 
+export function resolveContextMetadata(
+  database: SqliteDatabase,
+  agentId: string,
+  targetType: "agent" | "assignment" = "agent"
+): ContextMetadataRecord | null {
+  try {
+    return getContextMetadata(database, agentId, targetType);
+  } catch (error) {
+    if (
+      error instanceof ContextMetadataError &&
+      error.message === `Agent ${agentId} does not have recorded context metadata.`
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 type ContextMetadataRow = {
   id: string;
   context_version: string | null;

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -1,0 +1,204 @@
+import type { SqliteDatabase } from "./sqlite.js";
+
+export type ContextTarget = {
+  agentId?: string;
+  assignmentId?: string;
+};
+
+export type SetContextMetadataInput = ContextTarget & {
+  contextVersion: string;
+  updatedBy?: string;
+};
+
+export type ContextMetadataRecord = {
+  targetType: "agent" | "assignment";
+  agentId: string;
+  contextVersion: string;
+  contextUpdateMode: string;
+  contextUpdatedAt: string;
+  contextUpdatedBy: string | null;
+};
+
+export class ContextMetadataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContextMetadataError";
+  }
+}
+
+export function applyContextMetadataSchema(database: SqliteDatabase): void {
+  ensureColumn(database, "agents", "context_version", "TEXT");
+  ensureColumn(database, "agents", "context_update_mode", "TEXT");
+  ensureColumn(database, "agents", "context_updated_at", "TEXT");
+  ensureColumn(database, "agents", "context_updated_by", "TEXT");
+}
+
+export function setContextMetadata(
+  database: SqliteDatabase,
+  input: SetContextMetadataInput
+): ContextMetadataRecord {
+  const contextVersion = normalizeRequiredText(input.contextVersion, "context-version");
+  const updatedBy = normalizeOptionalText(input.updatedBy);
+  const target = resolveContextTarget(database, input);
+
+  database
+    .prepare(
+      `
+      UPDATE agents
+      SET
+        context_version = ?,
+        context_update_mode = ?,
+        context_updated_at = CURRENT_TIMESTAMP,
+        context_updated_by = ?
+      WHERE id = ?
+      `
+    )
+    .run(contextVersion, "manual_ssh", updatedBy, target.agentId);
+
+  return getContextMetadata(database, target.agentId, target.targetType);
+}
+
+export function getContextMetadata(
+  database: SqliteDatabase,
+  agentId: string,
+  targetType: "agent" | "assignment" = "agent"
+): ContextMetadataRecord {
+  const row = database
+    .prepare(
+      `
+      SELECT
+        id,
+        context_version,
+        context_update_mode,
+        context_updated_at,
+        context_updated_by
+      FROM agents
+      WHERE id = ?
+      LIMIT 1
+      `
+    )
+    .get(agentId) as ContextMetadataRow | undefined;
+
+  if (!row) {
+    throw new ContextMetadataError(`Unknown agent id ${agentId}.`);
+  }
+
+  if (
+    typeof row.context_version !== "string" ||
+    row.context_version.trim() === "" ||
+    typeof row.context_update_mode !== "string" ||
+    row.context_update_mode.trim() === "" ||
+    typeof row.context_updated_at !== "string" ||
+    row.context_updated_at.trim() === ""
+  ) {
+    throw new ContextMetadataError(`Agent ${agentId} does not have recorded context metadata.`);
+  }
+
+  return {
+    targetType,
+    agentId: row.id,
+    contextVersion: row.context_version,
+    contextUpdateMode: row.context_update_mode,
+    contextUpdatedAt: row.context_updated_at,
+    contextUpdatedBy: normalizeOptionalText(row.context_updated_by)
+  };
+}
+
+type ContextMetadataRow = {
+  id: string;
+  context_version: string | null;
+  context_update_mode: string | null;
+  context_updated_at: string | null;
+  context_updated_by: string | null;
+};
+
+type AssignmentTargetRow = {
+  id: string;
+  agent_id: string;
+  active: number;
+};
+
+function resolveContextTarget(
+  database: SqliteDatabase,
+  input: ContextTarget
+): { agentId: string; targetType: "agent" | "assignment" } {
+  const hasAgentId = normalizeOptionalText(input.agentId) !== null;
+  const hasAssignmentId = normalizeOptionalText(input.assignmentId) !== null;
+
+  if (hasAgentId === hasAssignmentId) {
+    throw new ContextMetadataError("Provide exactly one of --agent-id or --assignment-id.");
+  }
+
+  if (hasAgentId) {
+    const agentId = normalizeOptionalText(input.agentId) as string;
+    const row = database
+      .prepare(
+        `
+        SELECT id
+        FROM agents
+        WHERE id = ?
+        LIMIT 1
+        `
+      )
+      .get(agentId) as { id: string } | undefined;
+
+    if (!row) {
+      throw new ContextMetadataError(`Unknown agent id ${agentId}.`);
+    }
+
+    return { agentId: row.id, targetType: "agent" };
+  }
+
+  const assignmentId = normalizeOptionalText(input.assignmentId) as string;
+  const row = database
+    .prepare(
+      `
+      SELECT id, agent_id, active
+      FROM user_assignments
+      WHERE id = ? AND active = 1
+      LIMIT 1
+      `
+    )
+    .get(assignmentId) as AssignmentTargetRow | undefined;
+
+  if (!row) {
+    throw new ContextMetadataError(`Unknown active assignment id ${assignmentId}.`);
+  }
+
+  return { agentId: row.agent_id, targetType: "assignment" };
+}
+
+function normalizeRequiredText(value: string, label: string): string {
+  const normalized = normalizeOptionalText(value);
+  if (!normalized) {
+    throw new ContextMetadataError(`${label} is required.`);
+  }
+
+  return normalized;
+}
+
+function normalizeOptionalText(value: string | undefined | null): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized === "" ? null : normalized;
+}
+
+function ensureColumn(
+  database: SqliteDatabase,
+  tableName: string,
+  columnName: string,
+  columnType: string
+): void {
+  const hasColumn = database
+    .prepare(`PRAGMA table_info(${tableName})`)
+    .all() as Array<{ name: string }>;
+
+  if (hasColumn.some((column) => column.name === columnName)) {
+    return;
+  }
+
+  database.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnType};`);
+}

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,5 +1,6 @@
 import type { ClassifiedDiscordMessage } from "../relay/classification.js";
 import type { ConversationSession } from "./sessions.js";
+import type { ContextMetadataRecord } from "./context.js";
 import type { SqliteDatabase } from "./sqlite.js";
 
 export type PersistedMessage = {
@@ -12,6 +13,8 @@ export type PersistedMessage = {
 export type MessagePersistenceOptions = {
   session?: ConversationSession | null;
   runtime?: RuntimePersistenceMetadata | null;
+  contextMetadata?: ContextMetadataRecord | null;
+  environment?: string | null;
 };
 
 export type AgentReplyMessageInput = {
@@ -221,7 +224,13 @@ function buildRoutingMetadata(
   message: ClassifiedDiscordMessage,
   options: MessagePersistenceOptions
 ): Record<string, unknown> | null {
-  if (!message.routing && !options.session && !options.runtime) {
+  if (
+    !message.routing &&
+    !options.session &&
+    !options.runtime &&
+    !options.contextMetadata &&
+    !options.environment
+  ) {
     return null;
   }
 
@@ -234,6 +243,17 @@ function buildRoutingMetadata(
     discordChannelId: message.routing?.discordChannelId ?? message.event.channelId,
     sessionId: options.session?.id ?? null,
     openClawSessionKey: options.session?.openClawSessionKey ?? null,
-    openClawMessage: options.runtime?.message ?? null
+    openClawMessage: options.runtime?.message ?? null,
+    context_version: options.contextMetadata?.contextVersion ?? null,
+    context_update_mode: options.contextMetadata?.contextUpdateMode ?? null,
+    context_updated_at: options.contextMetadata?.contextUpdatedAt ?? null,
+    context_updated_by: options.contextMetadata?.contextUpdatedBy ?? null,
+    user_id: message.routing?.user.id ?? null,
+    expert_id: message.routing?.expert.id ?? null,
+    agent_id: message.routing?.agent.id ?? null,
+    discord_channel_id: message.routing?.discordChannelId ?? message.event.channelId,
+    session_id: options.session?.id ?? null,
+    assignment_id: message.routing?.assignmentId ?? null,
+    environment: options.environment ?? null
   };
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,6 +22,10 @@ CREATE TABLE IF NOT EXISTS agents (
   openclaw_agent_id TEXT NOT NULL UNIQUE,
   workspace_path TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'active',
+  context_version TEXT,
+  context_update_mode TEXT,
+  context_updated_at TEXT,
+  context_updated_by TEXT,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,4 +1,5 @@
 import type { SqliteDatabase } from "./sqlite.js";
+import { applyContextMetadataSchema } from "./context.js";
 import { PHASE_1_SCHEMA_SQL } from "./schema.js";
 
 export type SeedUser = {
@@ -100,6 +101,7 @@ export function validateRoutingSeed(value: unknown): asserts value is RoutingSee
 
 export function applyPhase1Schema(database: SqliteDatabase): void {
   database.exec(PHASE_1_SCHEMA_SQL);
+  applyContextMetadataSchema(database);
 }
 
 export function seedRoutingAssignments(database: SqliteDatabase, seed: RoutingSeedInput): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,8 @@ async function runDiscordBotEntrypoint() {
         database,
         openClaw,
         discord,
-        discordSelfUserId: discord.getSelfUserId()
+        discordSelfUserId: discord.getSelfUserId(),
+        environment: config.environment
       });
     }
   });

--- a/src/openclaw/README.md
+++ b/src/openclaw/README.md
@@ -17,7 +17,7 @@ then sends a `type: "req"` `connect` request with:
 - optional shared `auth.token`
 - signed top-level `device`, `locale`, and `userAgent`
 
-The supported client id and mode default to `cli` and `operator`.
+The supported client id and mode default to `cli` and `backend`.
 
 ## Device Identity
 

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -51,7 +51,7 @@ export type OpenClawGatewaySocket = {
 
 export const OPENCLAW_GATEWAY_CLIENT_DEFAULTS = {
   clientId: "cli",
-  clientMode: "operator",
+  clientMode: "backend",
   clientVersion: "0.1.0",
   clientPlatform: "node",
   deviceFamily: "server",

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -13,13 +13,24 @@ export type OpenClawGatewayRequest = {
   agentId: string;
   sessionKey: string;
   message: string;
-  metadata: {
-    discordMessageId: string;
-    discordChannelId: string;
-    userId: string;
-    expertId: string;
-    assignmentId: string;
-  };
+  metadata: OpenClawRequestMetadata;
+};
+
+export type OpenClawRequestMetadata = {
+  discordMessageId: string;
+  discordChannelId: string;
+  userId: string;
+  expertId: string;
+  assignmentId: string;
+  environment?: string | null;
+  context_version?: string | null;
+  context_update_mode?: string | null;
+  session_id?: string | null;
+  user_id?: string | null;
+  expert_id?: string | null;
+  agent_id?: string | null;
+  assignment_id?: string | null;
+  discord_channel_id?: string | null;
 };
 
 export type OpenClawGatewayClient = {
@@ -110,6 +121,32 @@ export function createUnconfiguredOpenClawGateway(): OpenClawGatewayClient {
         status: "not_configured",
         message: "OpenClaw gateway is not wired in this bootstrap slice."
       };
+    }
+  };
+}
+
+export function buildOpenRouterMetadata(metadata: OpenClawRequestMetadata): {
+  user: string | null;
+  session_id: string | null;
+  trace: Record<string, string | null>;
+} {
+  const userId = metadata.user_id ?? metadata.userId;
+  const sessionId = metadata.session_id ?? null;
+
+  return {
+    user: userId ?? null,
+    session_id: sessionId,
+    trace: {
+      discord_message_id: metadata.discordMessageId,
+      discord_channel_id: metadata.discord_channel_id ?? metadata.discordChannelId,
+      user_id: userId ?? null,
+      expert_id: metadata.expert_id ?? metadata.expertId,
+      agent_id: metadata.agent_id ?? null,
+      assignment_id: metadata.assignment_id ?? metadata.assignmentId,
+      environment: metadata.environment ?? null,
+      context_version: metadata.context_version ?? null,
+      context_update_mode: metadata.context_update_mode ?? null,
+      session_id: sessionId
     }
   };
 }

--- a/src/relay/discord.ts
+++ b/src/relay/discord.ts
@@ -5,6 +5,7 @@ import {
   type PersistedMessage,
   type RuntimePersistenceMetadata
 } from "../db/messages.js";
+import { resolveContextMetadata } from "../db/context.js";
 import { resolveChannelRouting } from "../db/routing.js";
 import { getOrCreateConversationSession, type ConversationSession } from "../db/sessions.js";
 import type { SqliteDatabase } from "../db/sqlite.js";
@@ -45,6 +46,7 @@ export type ProcessDiscordMessageDependencies = {
   openClaw: AgentRuntimeClient;
   discord?: DiscordOutboundAdapter;
   discordSelfUserId?: string;
+  environment?: string;
 };
 
 export type ProcessedDiscordMessage = {
@@ -91,8 +93,14 @@ export async function processNormalizedDiscordEvent(
   const session = classified.shouldForwardToOpenClaw && routing
     ? getOrCreateConversationSession(dependencies.database, routing)
     : null;
+  const contextMetadata = classified.shouldForwardToOpenClaw && routing
+    ? resolveContextMetadata(dependencies.database, routing.agent.id)
+    : null;
+  const environment = dependencies.environment ?? process.env.NODE_ENV ?? "test";
   const persisted = persistClassifiedMessage(dependencies.database, classified, {
-    session
+    session,
+    contextMetadata,
+    environment
   });
   const openClaw = classified.shouldForwardToOpenClaw && routing && session
     ? await sendToOpenClawWithFailureCapture(dependencies.openClaw, {
@@ -111,7 +119,9 @@ export async function processNormalizedDiscordEvent(
   const updatedPersisted = openClaw
     ? persistClassifiedMessage(dependencies.database, classified, {
         session,
-        runtime: toRuntimePersistenceMetadata(openClaw)
+        runtime: toRuntimePersistenceMetadata(openClaw),
+        contextMetadata,
+        environment
       })
     : persisted;
   const agentReply = openClaw?.reply && routing && session && dependencies.discord

--- a/src/relay/discord.ts
+++ b/src/relay/discord.ts
@@ -28,13 +28,24 @@ export type AgentRuntimeRequest = {
   agentId: string;
   sessionKey: string;
   message: string;
-  metadata: {
-    discordMessageId: string;
-    discordChannelId: string;
-    userId: string;
-    expertId: string;
-    assignmentId: string;
-  };
+  metadata: AgentRuntimeRequestMetadata;
+};
+
+export type AgentRuntimeRequestMetadata = {
+  discordMessageId: string;
+  discordChannelId: string;
+  userId: string;
+  expertId: string;
+  assignmentId: string;
+  environment?: string | null;
+  context_version?: string | null;
+  context_update_mode?: string | null;
+  session_id?: string | null;
+  user_id?: string | null;
+  expert_id?: string | null;
+  agent_id?: string | null;
+  assignment_id?: string | null;
+  discord_channel_id?: string | null;
 };
 
 export type AgentRuntimeClient = {
@@ -112,7 +123,16 @@ export async function processNormalizedDiscordEvent(
           discordChannelId: event.channelId,
           userId: routing.user.id,
           expertId: routing.expert.id,
-          assignmentId: routing.assignmentId
+          assignmentId: routing.assignmentId,
+          environment: dependencies.environment ?? process.env.NODE_ENV ?? "test",
+          context_version: contextMetadata?.contextVersion ?? null,
+          context_update_mode: contextMetadata?.contextUpdateMode ?? null,
+          session_id: session.id,
+          user_id: routing.user.id,
+          expert_id: routing.expert.id,
+          agent_id: routing.agent.id,
+          assignment_id: routing.assignmentId,
+          discord_channel_id: event.channelId
         }
       })
     : null;

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -1,17 +1,9 @@
 import type { RelayConfig } from "../config/index.js";
 import type { RelayStore, StoredMessage } from "../db/index.js";
 import type { NormalizedDiscordEvent } from "../discord/index.js";
+import type { OpenClawGatewayReply, OpenClawRequestMetadata } from "../openclaw/index.js";
 
-export type RelayRuntimeReply = {
-  status: "ok" | "not_configured" | "failed";
-  message?: string;
-  reply?: {
-    content: string;
-    runtimeMessageId?: string;
-  };
-  traceId?: string;
-  providerResponseId?: string;
-};
+export type RelayRuntimeReply = OpenClawGatewayReply;
 
 export type RelayResult = {
   accepted: boolean;
@@ -27,7 +19,7 @@ export type IntentiveRelayDependencies = {
       agentId: string;
       sessionKey: string;
       message: string;
-      metadata: Record<string, string>;
+      metadata: OpenClawRequestMetadata;
     }): Promise<RelayRuntimeReply>;
   };
 };

--- a/test/context-metadata.test.mjs
+++ b/test/context-metadata.test.mjs
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
 import { runContextSetCommand } from "../dist/context.js";
+import { ContextMetadataError, resolveContextMetadata } from "../dist/db/context.js";
 import { seedRoutingAssignments } from "../dist/db/seed.js";
 
 const seed = {
@@ -269,6 +270,27 @@ test("manual context metadata rejects unknown agent and assignment ids", async (
           }
         ),
       /Unknown active assignment id assignment_missing\./
+    );
+  } finally {
+    database.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("missing context metadata resolves to null with a stable error code", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "intentive-context-resolve-"));
+  const database = new DatabaseSync(join(tempDir, "context.sqlite"));
+
+  try {
+    seedRoutingAssignments(database, seed);
+
+    assert.equal(resolveContextMetadata(database, "agent_local_alex"), null);
+    assert.throws(
+      () => resolveContextMetadata(database, "agent_missing"),
+      (error) =>
+        error instanceof ContextMetadataError &&
+        error.code === "unknown_agent" &&
+        /Unknown agent id agent_missing\./.test(error.message)
     );
   } finally {
     database.close();

--- a/test/context-metadata.test.mjs
+++ b/test/context-metadata.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { runContextSetCommand } from "../dist/context.js";
+import { seedRoutingAssignments } from "../dist/db/seed.js";
+
+const seed = {
+  users: [
+    {
+      id: "user_local_alex",
+      discordUserId: "discord-user-local-alex",
+      displayName: "Alex Demo"
+    }
+  ],
+  experts: [
+    {
+      id: "expert_local_river",
+      discordUserId: "discord-expert-local-river",
+      displayName: "River Expert"
+    }
+  ],
+  agents: [
+    {
+      id: "agent_local_alex",
+      openClawAgentId: "openclaw-agent-local-alex",
+      workspacePath: "/tmp/openclaw/workspaces/alex-demo"
+    }
+  ],
+  userAssignments: [
+    {
+      id: "assignment_local_alex_private_channel",
+      userId: "user_local_alex",
+      expertId: "expert_local_river",
+      agentId: "agent_local_alex",
+      discordChannelId: "discord-channel-private-alex"
+    }
+  ]
+};
+
+test("manual context metadata can be recorded for an agent", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "intentive-context-"));
+  const databasePath = join(tempDir, "context.sqlite");
+  const database = new DatabaseSync(databasePath);
+
+  try {
+    seedRoutingAssignments(database, seed);
+
+    const result = await runContextSetCommand(
+      [
+        "--agent-id",
+        "agent_local_alex",
+        "--context-version",
+        "alex-week-2026-04-17",
+        "--updated-by",
+        "Srujan"
+      ],
+      {
+        DATABASE_PATH: databasePath
+      }
+    );
+
+    assert.equal(result.targetType, "agent");
+    assert.equal(result.agentId, "agent_local_alex");
+    assert.equal(result.contextVersion, "alex-week-2026-04-17");
+    assert.equal(result.contextUpdateMode, "manual_ssh");
+    assert.equal(result.contextUpdatedBy, "Srujan");
+    assert.equal(typeof result.contextUpdatedAt, "string");
+    assert.notEqual(result.contextUpdatedAt.trim(), "");
+
+    const row = database
+      .prepare(
+        `
+        SELECT
+          context_version,
+          context_update_mode,
+          context_updated_at,
+          context_updated_by
+        FROM agents
+        WHERE id = ?
+        `
+      )
+      .get("agent_local_alex");
+
+    assert.deepEqual(
+      { ...row },
+      {
+        context_version: "alex-week-2026-04-17",
+        context_update_mode: "manual_ssh",
+        context_updated_at: row.context_updated_at,
+        context_updated_by: "Srujan"
+      }
+    );
+    assert.equal(typeof row.context_updated_at, "string");
+    assert.notEqual(row.context_updated_at.trim(), "");
+  } finally {
+    database.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manual context metadata updates overwrite the previous label", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "intentive-context-repeat-"));
+  const databasePath = join(tempDir, "context.sqlite");
+  const database = new DatabaseSync(databasePath);
+
+  try {
+    seedRoutingAssignments(database, seed);
+
+    await runContextSetCommand(
+      [
+        "--assignment-id",
+        "assignment_local_alex_private_channel",
+        "--context-version",
+        "alex-week-2026-04-17",
+        "--updated-by",
+        "Srujan"
+      ],
+      {
+        DATABASE_PATH: databasePath
+      }
+    );
+
+    const secondResult = await runContextSetCommand(
+      [
+        "--assignment-id",
+        "assignment_local_alex_private_channel",
+        "--context-version",
+        "alex-week-2026-04-18",
+        "--updated-by",
+        "Srujan Day 2"
+      ],
+      {
+        DATABASE_PATH: databasePath
+      }
+    );
+
+    assert.equal(secondResult.targetType, "assignment");
+    assert.equal(secondResult.agentId, "agent_local_alex");
+    assert.equal(secondResult.contextVersion, "alex-week-2026-04-18");
+    assert.equal(secondResult.contextUpdateMode, "manual_ssh");
+    assert.equal(secondResult.contextUpdatedBy, "Srujan Day 2");
+
+    const counts = database
+      .prepare(
+        `
+        SELECT COUNT(*) AS count
+        FROM agents
+        `
+      )
+      .get();
+
+    assert.equal(counts.count, 1);
+
+    const row = database
+      .prepare(
+        `
+        SELECT
+          context_version,
+          context_update_mode,
+          context_updated_by
+        FROM agents
+        WHERE id = ?
+        `
+      )
+      .get("agent_local_alex");
+
+    assert.deepEqual({ ...row }, {
+      context_version: "alex-week-2026-04-18",
+      context_update_mode: "manual_ssh",
+      context_updated_by: "Srujan Day 2"
+    });
+  } finally {
+    database.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manual context metadata rejects an empty context version", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "intentive-context-empty-"));
+  const databasePath = join(tempDir, "context.sqlite");
+  const database = new DatabaseSync(databasePath);
+
+  try {
+    seedRoutingAssignments(database, seed);
+
+    await assert.rejects(
+      () =>
+        runContextSetCommand(
+          [
+            "--agent-id",
+            "agent_local_alex",
+            "--context-version",
+            "   ",
+            "--updated-by",
+            "Srujan"
+          ],
+          {
+            DATABASE_PATH: databasePath
+          }
+        ),
+      /context-version is required\./
+    );
+
+    const row = database
+      .prepare(
+        `
+        SELECT
+          context_version,
+          context_update_mode,
+          context_updated_at,
+          context_updated_by
+        FROM agents
+        WHERE id = ?
+        `
+      )
+      .get("agent_local_alex");
+
+    assert.deepEqual({ ...row }, {
+      context_version: null,
+      context_update_mode: null,
+      context_updated_at: null,
+      context_updated_by: null
+    });
+  } finally {
+    database.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manual context metadata rejects unknown agent and assignment ids", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "intentive-context-missing-"));
+  const databasePath = join(tempDir, "context.sqlite");
+  const database = new DatabaseSync(databasePath);
+
+  try {
+    seedRoutingAssignments(database, seed);
+
+    await assert.rejects(
+      () =>
+        runContextSetCommand(
+          [
+            "--agent-id",
+            "agent_missing",
+            "--context-version",
+            "alex-week-2026-04-17"
+          ],
+          {
+            DATABASE_PATH: databasePath
+          }
+        ),
+      /Unknown agent id agent_missing\./
+    );
+
+    await assert.rejects(
+      () =>
+        runContextSetCommand(
+          [
+            "--assignment-id",
+            "assignment_missing",
+            "--context-version",
+            "alex-week-2026-04-17"
+          ],
+          {
+            DATABASE_PATH: databasePath
+          }
+        ),
+      /Unknown active assignment id assignment_missing\./
+    );
+  } finally {
+    database.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/message-classification.test.mjs
+++ b/test/message-classification.test.mjs
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
 import { persistClassifiedMessage } from "../dist/db/messages.js";
+import { setContextMetadata } from "../dist/db/context.js";
 import { resolveChannelRouting } from "../dist/db/routing.js";
 import { seedRoutingAssignments } from "../dist/db/seed.js";
 import { createRecordingDiscordAdapter } from "../dist/discord/index.js";
@@ -150,6 +151,11 @@ test("relay processing persists expert messages without calling OpenClaw", async
 
 test("mapped user messages create a session and call the OpenClaw gateway client", async () => {
   await withDatabase(async (database) => {
+    setContextMetadata(database, {
+      agentId: "agent_local_alex",
+      contextVersion: "alex-week-2026-04-17",
+      updatedBy: "Srujan"
+    });
     const calls = [];
     const openClaw = {
       async sendUserMessage(request) {
@@ -200,10 +206,66 @@ test("mapped user messages create a session and call the OpenClaw gateway client
     assert.equal(stored.openclaw_status, "ok");
     assert.equal(stored.openclaw_trace_id, "trace-local-1");
     assert.equal(stored.openclaw_provider_response_id, "provider-response-1");
+    assert.equal(routingMetadata.context_version, "alex-week-2026-04-17");
+    assert.equal(routingMetadata.context_update_mode, "manual_ssh");
+    assert.equal(typeof routingMetadata.context_updated_at, "string");
+    assert.notEqual(routingMetadata.context_updated_at.trim(), "");
+    assert.equal(routingMetadata.context_updated_by, "Srujan");
+    assert.equal(routingMetadata.user_id, "user_local_alex");
+    assert.equal(routingMetadata.expert_id, "expert_local_river");
+    assert.equal(routingMetadata.agent_id, "agent_local_alex");
+    assert.equal(routingMetadata.discord_channel_id, "discord-channel-private-alex");
+    assert.equal(routingMetadata.session_id, "session_discord-channel-private-alex_openclaw-agent-local-alex");
+    assert.equal(
+      routingMetadata.assignment_id,
+      "assignment_local_alex_private_channel"
+    );
+    assert.equal(routingMetadata.environment, "test");
     assert.equal(
       routingMetadata.openClawSessionKey,
       "discord:discord-channel-private-alex:agent:openclaw-agent-local-alex"
     );
+  });
+});
+
+test("mapped user messages still route when context metadata is unset", async () => {
+  await withDatabase(async (database) => {
+    const calls = [];
+    const openClaw = {
+      async sendUserMessage(request) {
+        calls.push(request);
+        return {
+          status: "ok",
+          traceId: "trace-local-2",
+          providerResponseId: "provider-response-2"
+        };
+      }
+    };
+
+    const result = await processDiscordMessagePayload(
+      {
+        id: "discord-message-route-user-2",
+        channelId: "discord-channel-private-alex",
+        author: { id: "discord-user-local-alex" },
+        content: "I still need the first step.",
+        timestamp: "2026-04-16T00:02:51.000Z"
+      },
+      { database, openClaw }
+    );
+
+    const stored = selectStoredMessage(database, "discord-message-route-user-2");
+    const routingMetadata = JSON.parse(stored.routing_metadata_json);
+
+    assert.equal(result.classified.messageType, "user_message");
+    assert.equal(result.openClaw?.status, "ok");
+    assert.equal(routingMetadata.context_version, null);
+    assert.equal(routingMetadata.context_update_mode, null);
+    assert.equal(routingMetadata.context_updated_at, null);
+    assert.equal(routingMetadata.context_updated_by, null);
+    assert.equal(routingMetadata.environment, "test");
+    assert.equal(routingMetadata.user_id, "user_local_alex");
+    assert.equal(routingMetadata.assignment_id, "assignment_local_alex_private_channel");
+    assert.equal(calls.length, 1);
   });
 });
 

--- a/test/message-classification.test.mjs
+++ b/test/message-classification.test.mjs
@@ -194,7 +194,16 @@ test("mapped user messages create a session and call the OpenClaw gateway client
           discordChannelId: "discord-channel-private-alex",
           userId: "user_local_alex",
           expertId: "expert_local_river",
-          assignmentId: "assignment_local_alex_private_channel"
+          assignmentId: "assignment_local_alex_private_channel",
+          session_id: "session_discord-channel-private-alex_openclaw-agent-local-alex",
+          user_id: "user_local_alex",
+          expert_id: "expert_local_river",
+          agent_id: "agent_local_alex",
+          assignment_id: "assignment_local_alex_private_channel",
+          discord_channel_id: "discord-channel-private-alex",
+          environment: "test",
+          context_version: "alex-week-2026-04-17",
+          context_update_mode: "manual_ssh"
         }
       }
     ]);

--- a/test/openclaw-gateway-client.test.mjs
+++ b/test/openclaw-gateway-client.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createOpenClawGatewayClient } from "../dist/openclaw/index.js";
+import { buildOpenRouterMetadata, createOpenClawGatewayClient } from "../dist/openclaw/index.js";
 
 const signedAtMs = 1_710_000_000_000;
 
@@ -507,6 +507,43 @@ test("OpenClaw client waits for a fresh challenge after reconnect", async () => 
   assert.equal((await secondResponse).reply.content, "Second answer.");
 
   client.close();
+});
+
+test("OpenClaw metadata helper maps relay IDs into OpenRouter-friendly fields", () => {
+  assert.deepEqual(
+    buildOpenRouterMetadata({
+      discordMessageId: "discord-message-42",
+      discordChannelId: "discord-channel-42",
+      userId: "user-42",
+      expertId: "expert-42",
+      assignmentId: "assignment-42",
+      environment: "test",
+      context_version: "alex-week-2026-04-17",
+      context_update_mode: "manual_ssh",
+      session_id: "session-42",
+      user_id: "user-42",
+      expert_id: "expert-42",
+      agent_id: "agent-42",
+      assignment_id: "assignment-42",
+      discord_channel_id: "discord-channel-42"
+    }),
+    {
+      user: "user-42",
+      session_id: "session-42",
+      trace: {
+        discord_message_id: "discord-message-42",
+        discord_channel_id: "discord-channel-42",
+        user_id: "user-42",
+        expert_id: "expert-42",
+        agent_id: "agent-42",
+        assignment_id: "assignment-42",
+        environment: "test",
+        context_version: "alex-week-2026-04-17",
+        context_update_mode: "manual_ssh",
+        session_id: "session-42"
+      }
+    }
+  );
 });
 
 class FakeOpenClawSocket {

--- a/test/openclaw-gateway-client.test.mjs
+++ b/test/openclaw-gateway-client.test.mjs
@@ -142,6 +142,42 @@ test("OpenClaw client waits for connect.challenge and signs device connect", asy
   client.close();
 });
 
+test("OpenClaw client defaults to gateway-compatible backend mode", async () => {
+  const identity = await createDeviceIdentity();
+  const sockets = [];
+  const client = createOpenClawGatewayClient(
+    {
+      gatewayUrl: "wss://openclaw.test/gateway",
+      deviceIdentityJwk: identity.privateJwk,
+      requestTimeoutMs: 25
+    },
+    {
+      createWebSocket(url) {
+        const socket = new FakeOpenClawSocket(url);
+        sockets.push(socket);
+        return socket;
+      },
+      now: () => signedAtMs
+    }
+  );
+
+  const responsePromise = client.sendUserMessage(openClawRequest());
+  const socket = sockets[0];
+
+  await socket.emitGatewayMessage({
+    v: 3,
+    type: "event",
+    event: "connect.challenge",
+    payload: { nonce: "challenge-nonce-default-mode" }
+  });
+
+  await waitFor(() => socket.sentFrames.length === 1);
+  assert.equal(socket.sentFrames[0].params.client.mode, "backend");
+
+  socket.close();
+  await responsePromise;
+});
+
 test("OpenClaw client times out when connect.challenge is not delivered", async () => {
   const identity = await createDeviceIdentity();
   const sockets = [];


### PR DESCRIPTION
## Problem
- Phase 2 needed to carry manual context metadata from the relay layer into persistence and OpenClaw, but the previous wiring only handled the narrower phase 1 flow.
- The system also needed a cleaner operational path for validating the phase 2 manual pilot without losing traceability in stored messages.

## Solution
- Added a context metadata model and persistence path so routed Discord messages can record manual context updates alongside session and relay metadata.
- Extended the OpenClaw boundary to accept richer request metadata and map relay identifiers into OpenRouter-friendly trace fields.
- Added a manual pilot smoke document and supporting tests to keep the phase 2 workflow verifiable.

## Key Changes
- Introduced context metadata resolution and SQLite persistence for agent context updates.
- Expanded message persistence to store OpenClaw status plus context fields on routed turns.
- Updated relay processing to attach context metadata before and after OpenClaw calls.
- Broadened the OpenClaw request contract to carry relay IDs, environment, and context fields.
- Added coverage for context metadata storage, message classification, and OpenClaw metadata mapping.

## Impact
- Behavior: routed messages now preserve manual context state end-to-end instead of dropping it at the boundary.
- Reliability: persisted records now carry enough metadata to reconstruct and debug phase 2 runs.
- Developer workflow: the manual pilot has a documented smoke path and test coverage for the new metadata contract.
- Performance: no intended performance change beyond the added persistence fields.
- Breaking changes: the OpenClaw request metadata shape is expanded to support the new trace fields.

## Testing
- Automated tests: `npm test`
- Validation: branch replay was checked against `main` to avoid reintroducing the deleted `docs/agents` surface into review diff
- Validation: 36 tests passed, including new context-metadata and OpenClaw metadata mapping coverage